### PR TITLE
handle service wait and sim time launch

### DIFF
--- a/node_test/src/node_test/test_filter.py
+++ b/node_test/src/node_test/test_filter.py
@@ -61,6 +61,7 @@ If the input or the output message should be empty, place None.
 """
 
 import sys
+import time
 import unittest
 import rospy
 import rostopic
@@ -82,6 +83,18 @@ class FilterMsgTest(unittest.TestCase):
 
     def setUp(self):
         rospy.init_node(CLASSNAME)
+
+        # warn on /use_sim_time is true
+        use_sim_time = rospy.get_param('/use_sim_time', False)
+        t_start = time.time()
+        while not rospy.is_shutdown() and \
+                use_sim_time and (rospy.Time.now() == rospy.Time(0)):
+            rospy.logwarn_throttle(
+                1, '/use_sim_time is specified and rostime is 0, /clock is published?')
+            if time.time() - t_start > 10:
+                self.fail('Timed out (10s) of /clock publication.')
+            # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
+            time.sleep(0.1)
 
     def test_filter(self):
         self.filters = list()

--- a/node_test/src/node_test/test_service.py
+++ b/node_test/src/node_test/test_service.py
@@ -58,6 +58,7 @@ If the input or the output should be empty, place None.
 """
 
 import sys
+import time
 import unittest
 import rospy
 import rosservice
@@ -71,11 +72,8 @@ CLASSNAME = 'servicetest'
 class ServiceTest(unittest.TestCase):
     def __init__(self, *args):
         super(ServiceTest, self).__init__(*args)
-
-    def setUp(self):
         rospy.init_node(CLASSNAME)
 
-    def test_service(self):
         self.calls = list()
 
         try:
@@ -100,6 +98,7 @@ class ServiceTest(unittest.TestCase):
                 if srv_data['output'] == 'None':
                     rospy.logwarn('None output converted to empty output')
                     srv_data['output'] = dict()
+
                 self.calls.append(srv_data)
         except KeyError as err:
             msg_err = "service_test not initialized properly"
@@ -108,6 +107,46 @@ class ServiceTest(unittest.TestCase):
                 rospy.get_caller_id(),
                 rospy.resolve_name(err.args[0]))
             self.fail(msg_err)
+
+    def setUp(self):
+        # warn on /use_sim_time is true
+        use_sim_time = rospy.get_param('/use_sim_time', False)
+        self.t_start = time.time()
+        while not rospy.is_shutdown() and \
+                use_sim_time and (rospy.Time.now() == rospy.Time(0)):
+            rospy.logwarn_throttle(
+                1, '/use_sim_time is specified and rostime is 0, /clock is published?')
+            if time.time() - self.t_start > 10:
+                self.fail('Timed out (10s) of /clock publication.')
+            # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
+            time.sleep(0.1)
+
+    def test_advertise_service(self):
+        """Test services are advertised"""
+        t_start = self.t_start
+        s_name_set = set([ item['name'] for item in self.calls])
+        t_timeout_max = 10.0
+
+        while not rospy.is_shutdown():
+            t_now = time.time()
+            t_elapsed = t_now - t_start
+            if not s_name_set:
+                break
+            if t_elapsed > t_timeout_max:
+                break
+
+            for s_name in rosservice.get_service_list():
+                if s_name in s_name_set:
+                    s_name_set.remove(s_name)
+            time.sleep(0.05)
+
+        # All services should have been detected
+        assert not s_name_set, \
+            'services [%s] not advertized on time' % (s_name_set)
+
+        rospy.loginfo("All services advertized on time")
+
+    def test_service_call(self):
 
         for item in self.calls:
             rospy.loginfo("Testing service {} with input parameters {}".format(
@@ -118,10 +157,8 @@ class ServiceTest(unittest.TestCase):
 
     def _test_service(self, srv_name, srv_input, srv_output):
         self.assert_(srv_name)
-
         all_services = rosservice.get_service_list()
         self.assertIn(srv_name, all_services)
-
         srv_class = rosservice.get_service_class_by_name(srv_name)
 
         try:


### PR DESCRIPTION
Service test was failing when the service was not yet advertise at the time it was looked for.

Following the method used in [advertistest](https://github.com/ros/ros_comm/blob/noetic-devel/tools/rostest/nodes/advertisetest#L150), a timeout is added to let time to the service to be accesible.

For now, the timeout time is hardcoded. Setting one per service may request more redesign work.

Also the management of the simulated time, as done in [advertisetest](https://github.com/ros/ros_comm/blob/noetic-devel/tools/rostest/nodes/advertisetest#L106) has been inserted.  